### PR TITLE
Fix linker errors

### DIFF
--- a/mmalpp/include/mmalpp_buffer.h
+++ b/mmalpp/include/mmalpp_buffer.h
@@ -311,7 +311,7 @@ private:
 };
 
 /// USED FOR DEBUG
-std::ostream& operator<<(std::ostream& os, const Buffer& b)
+inline std::ostream& operator<<(std::ostream& os, const Buffer& b)
 {
     for (auto i = b.begin(); i != b.end(); ++i)
         os << *i;

--- a/mmalpp/include/utils/exceptions/mmalpp_exceptions.h
+++ b/mmalpp/include/utils/exceptions/mmalpp_exceptions.h
@@ -13,7 +13,7 @@ namespace mmalpp_impl_ {
 /**
  * @brief If error code is one of them it throw an exception.
  */
-void e_check__(const MMAL_STATUS_T e_code_, const std::string& msg_)
+inline void e_check__(const MMAL_STATUS_T e_code_, const std::string& msg_)
 {
     switch (e_code_)
     {

--- a/mmalpp/include/utils/mmalpp_buffer_utils.h
+++ b/mmalpp/include/utils/mmalpp_buffer_utils.h
@@ -18,7 +18,7 @@ namespace mmalpp_impl_ {
  * This is useful for instance if a component needs to return a buffer header but still needs
  * access to it for some internal processing (e.g. reference frames in video codecs).
  */
-void
+inline void
 acquire_buffer_header_ (MMAL_BUFFER_HEADER_T* buffer_)
 { mmal_buffer_header_acquire(buffer_); }
 
@@ -31,14 +31,14 @@ acquire_buffer_header_ (MMAL_BUFFER_HEADER_T* buffer_)
  * Once pre-release is complete the buffer header is recycled with
  * mmal_buffer_header_release_continue.
  */
-void
+inline void
 release_buffer_header_ (MMAL_BUFFER_HEADER_T* buffer_)
 { mmal_buffer_header_release(buffer_); }
 
 /**
  * Reset a buffer header. Resets all header variables to default values.
  */
-void
+inline void
 reset_buffer_header_ (MMAL_BUFFER_HEADER_T* buffer_)
 { mmal_buffer_header_reset(buffer_); }
 
@@ -48,7 +48,7 @@ reset_buffer_header_ (MMAL_BUFFER_HEADER_T* buffer_)
  * but it will also acquire a reference to the source buffer header which will only be
  * released once the replicate has been released.
  */
-void
+inline void
 replicate_buffer_header_ (MMAL_BUFFER_HEADER_T* buffer_src_,
                           MMAL_BUFFER_HEADER_T* buffer_dst_)
 { if (MMAL_STATUS_T status = mmal_buffer_header_replicate(

--- a/mmalpp/include/utils/mmalpp_component_utils.h
+++ b/mmalpp/include/utils/mmalpp_component_utils.h
@@ -18,7 +18,7 @@ namespace mmalpp_impl_ {
  * Note that components are reference counted and creating a component automatically
  * acquires a reference to it.
  */
-MMAL_COMPONENT_T*
+inline MMAL_COMPONENT_T*
 create_component_(const char* name_)
 {
     MMAL_COMPONENT_T* component_;
@@ -34,7 +34,7 @@ create_component_(const char* name_)
  * Release an acquired reference on a component. Triggers the destruction of the component when
  * the last reference is being released.
  */
-void
+inline void
 release_component_(MMAL_COMPONENT_T* component_)
 { if (MMAL_STATUS_T status = mmal_component_release(component_); status)
         e_check__(status, "cannot release component: " +
@@ -43,7 +43,7 @@ release_component_(MMAL_COMPONENT_T* component_)
 /**
  * Enable processing on a component.
  */
-void
+inline void
 enable_component_(MMAL_COMPONENT_T* component_)
 { if (MMAL_STATUS_T status = mmal_component_enable(component_); status)
         e_check__(status, "cannot enable component: " +
@@ -52,7 +52,7 @@ enable_component_(MMAL_COMPONENT_T* component_)
 /**
  * Disable processing on a component.
  */
-void
+inline void
 disable_component_(MMAL_COMPONENT_T* component_)
 { if (MMAL_STATUS_T status = mmal_component_disable(component_); status)
         e_check__(status, "cannot disable component: " +

--- a/mmalpp/include/utils/mmalpp_connection_utils.h
+++ b/mmalpp/include/utils/mmalpp_connection_utils.h
@@ -23,7 +23,7 @@ namespace mmalpp_impl_ {
  * Note that connections are reference counted and creating a connection automatically
  * acquires a reference to it.
  */
-MMAL_CONNECTION_T*
+inline MMAL_CONNECTION_T*
 create_connection_(MMAL_PORT_T* src_, MMAL_PORT_T* dst_, uint32_t flags_)
 {
     MMAL_CONNECTION_T* connection_;
@@ -41,7 +41,7 @@ create_connection_(MMAL_PORT_T* src_, MMAL_PORT_T* dst_, uint32_t flags_)
  * although note that on creation, the connection automatically copies and commits the
  * output port's format to the input port.
  */
-void
+inline void
 enable_connection_(MMAL_CONNECTION_T* connection_)
 {
     if (MMAL_STATUS_T status = mmal_connection_enable(connection_); status)
@@ -53,7 +53,7 @@ enable_connection_(MMAL_CONNECTION_T* connection_)
 /**
  * Disable a connection.
  */
-void
+inline void
 disable_connection_(MMAL_CONNECTION_T* connection_)
 {
     if (MMAL_STATUS_T status = mmal_connection_disable(connection_); status)
@@ -67,7 +67,7 @@ disable_connection_(MMAL_CONNECTION_T* connection_)
  * Release an acquired reference on a connection. Triggers the destruction of the connection when
  * the last reference is being released.
  */
-void
+inline void
 destroy_connection_(MMAL_CONNECTION_T* connection_)
 {
     if (MMAL_STATUS_T status = mmal_connection_release(connection_); status)

--- a/mmalpp/include/utils/mmalpp_pool_utils.h
+++ b/mmalpp/include/utils/mmalpp_pool_utils.h
@@ -17,7 +17,7 @@ namespace mmalpp_impl_ {
  * Resize a pool of MMAL_BUFFER_HEADER_T. This allows modifying either the number of
  * allocated buffers, the payload size or both at the same time.
  */
-void
+inline void
 pool_resize_(MMAL_POOL_T* pool_, std::size_t headers_, uint32_t size_)
 { if (MMAL_STATUS_T status = mmal_pool_resize(
                 pool_, headers_, size_); status)
@@ -28,7 +28,7 @@ pool_resize_(MMAL_POOL_T* pool_, std::size_t headers_, uint32_t size_)
  * This will also deallocate all of the memory which was allocated when creating or
  * resizing the pool.
  */
-void
+inline void
 pool_release_(MMAL_POOL_T* pool_)
 { mmal_pool_destroy(pool_); }
 
@@ -39,7 +39,7 @@ pool_release_(MMAL_POOL_T* pool_)
  * The resize() function can be used to increase or decrease the number of buffer
  * headers, or the size of the payload buffers, after creation of the pool.
  */
-MMAL_POOL_T*
+inline MMAL_POOL_T*
 create_pool_(std::size_t headers_, uint32_t size_)
 { return mmal_pool_create(headers_, size_); }
 

--- a/mmalpp/include/utils/mmalpp_port_utils.h
+++ b/mmalpp/include/utils/mmalpp_port_utils.h
@@ -18,7 +18,7 @@ namespace mmalpp_impl_ {
  * the given callback must be NULL, while for a disconnected port,
  * the callback must be non-NULL.
  */
-void
+inline void
 enable_port_(MMAL_PORT_T* port_,
              MMAL_PORT_BH_CB_T cb_)
 { if (MMAL_STATUS_T status = mmal_port_enable(port_, cb_); status)
@@ -31,7 +31,7 @@ enable_port_(MMAL_PORT_T* port_,
  * If this is a connected output port, the input port to which it is connected shall
  * also be disabled. Any buffer pool shall be released.
  */
-void
+inline void
 disable_port_(MMAL_PORT_T* port_)
 { if (MMAL_STATUS_T status = mmal_port_disable(port_); status)
         e_check__(status, "cannot disable port: "
@@ -40,7 +40,7 @@ disable_port_(MMAL_PORT_T* port_)
 /**
  * Send a buffer header to a port.
  */
-void
+inline void
 port_send_buffer(MMAL_PORT_T* port_, MMAL_BUFFER_HEADER_T* buffer_)
 { if (MMAL_STATUS_T status = mmal_port_send_buffer(
                 port_, buffer_); status)
@@ -50,7 +50,7 @@ port_send_buffer(MMAL_PORT_T* port_, MMAL_BUFFER_HEADER_T* buffer_)
 /**
  * Commit format changes on a port.
  */
-void
+inline void
 commit_format_(MMAL_PORT_T* port_)
 { if (MMAL_STATUS_T status = mmal_port_format_commit(
                 port_); status)
@@ -61,7 +61,7 @@ commit_format_(MMAL_PORT_T* port_)
  * Shallow copy a format structure. It is worth noting that the extradata buffer
  * will not be copied in the new format.
  */
-void
+inline void
 copy_format_(MMAL_ES_FORMAT_T* src_, MMAL_ES_FORMAT_T* dst_)
 { mmal_format_copy(dst_, src_); }
 
@@ -75,7 +75,7 @@ copy_format_(MMAL_ES_FORMAT_T* src_, MMAL_ES_FORMAT_T* dst_)
  * It is also important to note that flushing will also reset the state of the port
  * and any processing which was buffered by the port will be lost.
  */
-void
+inline void
 flush_port_(MMAL_PORT_T* port_)
 { if (MMAL_STATUS_T status = mmal_port_flush(port_); status)
         e_check__(status, "cannot flush port "
@@ -84,7 +84,7 @@ flush_port_(MMAL_PORT_T* port_)
 /**
  * Set a parameter on a port.
  */
-void
+inline void
 set_parameters_to_port_(MMAL_PORT_T* port_,
                         MMAL_PARAMETER_HEADER_T* param_)
 { if (MMAL_STATUS_T status = mmal_port_parameter_set(
@@ -95,7 +95,7 @@ set_parameters_to_port_(MMAL_PORT_T* port_,
 /**
  * Set a parameter on a port.
  */
-void
+inline void
 set_boolean_to_port_(MMAL_PORT_T* port_,
                      uint32_t id_,
                      int32_t value_)
@@ -107,7 +107,7 @@ set_boolean_to_port_(MMAL_PORT_T* port_,
 /**
  * Set a parameter on a port.
  */
-void
+inline void
 set_uint64_to_port_(MMAL_PORT_T* port_,
                     uint32_t id_,
                     uint64_t value_)
@@ -119,7 +119,7 @@ set_uint64_to_port_(MMAL_PORT_T* port_,
 /**
  * Set a parameter on a port.
  */
-void
+inline void
 set_int64_to_port_(MMAL_PORT_T* port_,
                    uint32_t id_,
                    int64_t value_)
@@ -131,7 +131,7 @@ set_int64_to_port_(MMAL_PORT_T* port_,
 /**
  * Set a parameter on a port.
  */
-void
+inline void
 set_uint32_to_port_(MMAL_PORT_T* port_,
                     uint32_t id_,
                     uint32_t value_)
@@ -143,7 +143,7 @@ set_uint32_to_port_(MMAL_PORT_T* port_,
 /**
  * Set a parameter on a port.
  */
-void
+inline void
 set_int32_to_port_(MMAL_PORT_T* port_,
                    uint32_t id_,
                    int32_t value_)
@@ -155,7 +155,7 @@ set_int32_to_port_(MMAL_PORT_T* port_,
 /**
  * Set a parameter on a port.
  */
-void
+inline void
 set_rational_to_port_(MMAL_PORT_T* port_,
                       uint32_t id_,
                       int32_t num_,
@@ -169,7 +169,7 @@ set_rational_to_port_(MMAL_PORT_T* port_,
 /**
  * Set a parameter on a port.
  */
-void
+inline void
 set_string_to_port_(MMAL_PORT_T* port_,
                     uint32_t id_,
                     const std::string& value_)
@@ -188,7 +188,7 @@ set_string_to_port_(MMAL_PORT_T* port_,
  * The mmal_pool_resize() function can be used to increase or decrease the number of buffer
  * headers, or the size of the payload buffers, after creation of the pool.
  */
-MMAL_POOL_T*
+inline MMAL_POOL_T*
 port_pool_create_(MMAL_PORT_T* port_,
                   std::size_t headers_,
                   uint32_t size_)
@@ -199,7 +199,7 @@ port_pool_create_(MMAL_PORT_T* port_,
  * This will also deallocate all of the memory which was allocated when creating or
  * resizing the pool.
  */
-void
+inline void
 port_pool_release_(MMAL_PORT_T* port_,
                    MMAL_POOL_T* pool_)
 { mmal_port_pool_destroy(port_, pool_); }
@@ -207,7 +207,7 @@ port_pool_release_(MMAL_PORT_T* port_,
 /**
  * Send a Buffer to a specific port.
  */
-void
+inline void
 send_buffer_(MMAL_PORT_T* port_,
              MMAL_BUFFER_HEADER_T* buffer_)
 { if (MMAL_STATUS_T status = mmal_port_send_buffer(

--- a/mmalpp/include/utils/mmalpp_queue_utils.h
+++ b/mmalpp/include/utils/mmalpp_queue_utils.h
@@ -14,28 +14,28 @@ namespace mmalpp_impl_ {
 /**
  * Create a queue of MMAL_BUFFER_HEADER_T
  */
-MMAL_QUEUE_T*
+inline MMAL_QUEUE_T*
 create_queue_()
 { return mmal_queue_create(); }
 
 /**
  * Get the number of MMAL_BUFFER_HEADER_T currently in a queue.
  */
-unsigned int
+inline unsigned int
 get_queue_lenght_(MMAL_QUEUE_T* queue_)
 { return mmal_queue_length(queue_); }
 
 /**
  * Destroy a queue of MMAL_BUFFER_HEADER_T
  */
-void
+inline void
 release_queue_(MMAL_QUEUE_T* queue_)
 { return mmal_queue_destroy(queue_); }
 
 /**
  * Get a MMAL_BUFFER_HEADER_T from a queue
  */
-MMAL_BUFFER_HEADER_T*
+inline MMAL_BUFFER_HEADER_T*
 get_buffer_from_queue_no_time_(MMAL_QUEUE_T* queue_)
 { return mmal_queue_get(queue_); }
 
@@ -43,7 +43,7 @@ get_buffer_from_queue_no_time_(MMAL_QUEUE_T* queue_)
  * Wait for a MMAL_BUFFER_HEADER_T from a queue, up to a given timeout.
  * This is the same as a wait, except that it will abort in case of timeout.
  */
-MMAL_BUFFER_HEADER_T*
+inline MMAL_BUFFER_HEADER_T*
 wait_ms_from_queue_(MMAL_QUEUE_T* queue_, std::size_t interval_)
 { return mmal_queue_timedwait(queue_, interval_); }
 
@@ -51,14 +51,14 @@ wait_ms_from_queue_(MMAL_QUEUE_T* queue_, std::size_t interval_)
  * Wait for a MMAL_BUFFER_HEADER_T from a queue. This is the same as a get
  * except that this will block until a buffer header is available.
  */
-MMAL_BUFFER_HEADER_T*
+inline MMAL_BUFFER_HEADER_T*
 wait_from_queue_(MMAL_QUEUE_T* queue_)
 { return mmal_queue_wait(queue_); }
 
 /**
  * Put a MMAL_BUFFER_HEADER_T into a queue.
  */
-void
+inline void
 put_in_queue_(MMAL_QUEUE_T* queue_, MMAL_BUFFER_HEADER_T* buffer_)
 { mmal_queue_put(queue_, buffer_); }
 
@@ -67,7 +67,7 @@ put_in_queue_(MMAL_QUEUE_T* queue_, MMAL_BUFFER_HEADER_T* buffer_)
  * This is used when a buffer header was removed from the queue but not
  * fully processed and needs to be put back where it was originally taken.
  */
-void
+inline void
 put_back_in_queue_(MMAL_QUEUE_T* queue_, MMAL_BUFFER_HEADER_T* buffer_)
 { mmal_queue_put_back(queue_, buffer_); }
 
@@ -77,7 +77,7 @@ put_back_in_queue_(MMAL_QUEUE_T* queue_, MMAL_BUFFER_HEADER_T* buffer_)
  * If timeout is 0 it will get a Buffer without waiting. If timeout is less than 0
  * the function will block until a Buffer will be available.
  */
-MMAL_BUFFER_HEADER_T*
+inline MMAL_BUFFER_HEADER_T*
 get_buffer_from_queue_(MMAL_QUEUE_T* queue_, int timeout_ms_ = 0)
 {
     return (timeout_ms_ == 0) ?


### PR DESCRIPTION
This pull request fixes this issue #2 by adding `inline` to all free function definitions.